### PR TITLE
Fix `constant overflow int` compile error

### DIFF
--- a/jks/read.go
+++ b/jks/read.go
@@ -40,7 +40,7 @@ func Parse(raw []byte, opts *Options) (*Keystore, error) {
 	}
 	if magic != MagicNumber {
 		return nil, fmt.Errorf("invalid magic; expected 0x%08X "+
-			"but got 0x%08X", MagicNumber, magic)
+			"but got 0x%08X", uint32(MagicNumber), magic)
 	}
 
 	version, _, err := readUint32(buf, "file version")


### PR DESCRIPTION
On a Raspberry Pi (armv7l) compiling with go1.12.7 this commit fixes the following compile error:
```
# github.com/lwithers/minijks/jks
jks/read.go:42:26: constant 4277010157 overflows int
```

This compile error is not present on amd64